### PR TITLE
Add broken links check workflow

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,3 +1,6 @@
+# deployment workflow
+# ---------------------
+
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,23 @@
+# html site proofer
+# -------------------
+
+name: Links
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 8 * * 1'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - run: bundle exec jekyll build
+      - uses: anishathalye/proof-html@v2
+        with:
+          directory: ./_site
+          enforce_https: false

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -21,3 +21,6 @@ jobs:
         with:
           directory: ./_site
           enforce_https: false
+          # irgnored url underneath should be removed once citrineos is reachable by public
+          ignore_url: |
+            https://github.com/citrineos/citrineos

--- a/404.html
+++ b/404.html
@@ -1,25 +1,11 @@
 ---
 layout: default
 permalink: /404.html
-title: CitrineOS | 404
+title: 404
 ---
 
-<style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
-
-<div class="container">
-  <h1>404</h1>
+<div class="container" style="margin: 10px auto; max-width: 600px; text-align: center;">
+  <h1 style="margin: 30px 0; font-size: 4em; line-height: 1; letter-spacing: -1px;">404</h1>
 
   <p><strong>Oops!</strong></p>
   <p>The page you're looking for is not powered by us.</p>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you're looking to make modifications or simply set it up locally, here's what
 
 - **Navbar**: To add or modify navbar items, adjust the `_data/navigation.yml` file. Each item has a `name` and a `link`, some also have a `logo`. In this case the logo will be displayed and the name is the fallback in case the logo can not be shown. Follow the existing syntax pattern to add more navbar items.
 
-- **Content**: To add content to pages adjust the markdown files, e.g. framework.md. These pages start with Front Matter that starts and ends with `---`. In between a title can be chosen and the default layout is set.
+- **Content**: To add content to pages adjust the markdown files, e.g. framework.md. These pages start with Front Matter that starts and ends with `---`. In between these markings a title can be chosen and the default layout is set.
   - **Markdown**:
     Jekyll uses Markdown for content. If you're new to Markdown, here's a [quick guide](https://www.markdownguide.org/getting-started/).
 
@@ -37,3 +37,7 @@ If you're looking to make modifications or simply set it up locally, here's what
   Under `/utils/_fonts` a new font could be added. The font then also needs to be updated under `/assets/fonts` following the existing pattern.
   Under `/utiles/_variables` chosen colors can be adjusted.
   These changes will be reflected throughout all of the website.
+
+## Deployment
+
+This site uses github actions for deployment. The trigger is set up to deploy everytime changes are pushed to the branch `main`.

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: CitrineOS
 description: Documentation for the CitrineOS implementation of the Open Charge Point Protocol (OCPP).
 
 baseurl: ""
-url: "citrineos.github.io"
+url: "https://citrineos.github.io"
 
 plugins: 
   - jekyll-sitemap

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ description: Documentation for the CitrineOS implementation of the Open Charge P
 
 baseurl: ""
 url: "https://citrineos.github.io"
+author: S44 LLC
 
 plugins: 
   - jekyll-sitemap

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,12 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>{{ page.title }}</title>
     <link rel="stylesheet" href="/assets/css/styles.css" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap"
-      rel="stylesheet"
-    />
     <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico" />
     {% seo %}
   </head>

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -1,7 +1,7 @@
 footer {
   width: 100%;
   color: rgb(167, 165, 165);
-  font-size: 1.125rem;
+  font-size: 1rem;
   padding: 1rem;
   text-align: right;
 }

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -32,14 +32,11 @@ nav {
 
   a {
   font-weight: 300;
-  font-style: bold;
   font-size: 1.125rem;
   line-height: 1.4;
   color: $background-color;
   text-decoration: none;
   padding: 1rem 1.2rem;
-  transition: $background-color 0.3s;
-
   }
 
   a:hover {

--- a/framework.md
+++ b/framework.md
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: CitrineOS | Framework
+title: Framework
 ---
+
 # Framework
 
 Here you can read more about the framework.

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: CitrineOS | Home
+title: Home
 ---
 
 # Citrine OS: Empowering the Global EV Revolution with Open-Source Innovation

--- a/pre-setup.md
+++ b/pre-setup.md
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: CitrineOS | Pre-Setup
+title: Pre-Setup
 ---
+
 # Pre-Setup
 
 Here you can read more about the pre-setup.

--- a/quickstart.md
+++ b/quickstart.md
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: CitrineOS | Quickstart
+title: Quickstart
 ---
+
 # Quickstart
 
 Here you can read more about the quickstart.

--- a/references.md
+++ b/references.md
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: CitrineOS | References
+title: References
 ---
+
 # References
 
 Here you can find further references.


### PR DESCRIPTION
introduced html quality gateway that automatically checks all links to not be broken

html proof package runs in .github/workflows/links.yml
[documentation](https://github.com/anishathalye/proof-html)

ignored url in links.yml should be removed once citrineos repo is reachable by public