### PR TITLE
updated link to citrine homepage and discord

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -7,11 +7,11 @@
 - name: References
   link: /references.html
 - name: About 
-  link: https://s44-t4gh8ceb.webflow.io/citrineos
+  link: https://s44.team/citrineos
   logo: /assets/images/Citrine_Favicon_256_clear3.png
 - name: Github
   link: https://github.com/citrineos/citrineos
   logo: /assets/images/github-mark-white.svg
 - name: Discord
-  link: https://discord.gg/Tkt7xucXTk
+  link: https://discord.com/invite/qNngpxMg
   logo: /assets/images/discord-logo.svg


### PR DESCRIPTION
discord link doesn't show a user name but needs to be changed in 24hours