### PR TITLE
Add discord invite url that doesn't expire

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,5 +13,5 @@
   link: https://github.com/citrineos/citrineos
   logo: /assets/images/github-mark-white.svg
 - name: Discord
-  link: https://discord.com/invite/qNngpxMg
+  link: https://discord.gg/dpPpa9PG
   logo: /assets/images/discord-logo.svg


### PR DESCRIPTION
Discord invite is now by the citrineOS user.