### PR TITLE
Fix/fix quickstart doc

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -57,7 +57,7 @@ You now have a running CitrineOS server plus the supporting infrastructure, in t
 
 - [RabbitMQ](http://rabbitmq.com) for the OCPP 2.0.1 message bus
 
-- OCPP Citrine Server running the CSMS. You can retrieve the generated OpenAPI docs at [localhost:8081/docs](http://localhost:8081/docs)
+- OCPP Citrine Server running the CSMS. You can retrieve the generated OpenAPI docs at [localhost:8080/docs](http://localhost:8080/docs)
 
 > Please consider that this setup is the development environment and **do not** simply deploy it to an exposed environment with initial passwords!
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -15,10 +15,10 @@ In this section we assume you have set up your local machine with the prerequisi
     git clone https://github.com/citrineos/citrineos-core
     ```
 
-1. Navigate to the `citrineos-core/50_Server` directory and run the init-all script:
+1. Navigate to the `citrineos-core/Server` directory and run the init-all script:
 
     ```shell
-    cd citrineos-core/50_Server
+    cd citrineos-core/Server
     ./unix-init-install-all.sh
     ```
 


### PR DESCRIPTION
Fixed server path: It should be `citineos-core/Server` instead of `citrineos-core/50_Server`
Also in my case generated OpenAPI docs are available on port **8080** instead of port **8181**