### PR TITLE
Remove ./unix-init-install-all.sh instruction from Quickstart guide

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -15,18 +15,10 @@ In this section we assume you have set up your local machine with the prerequisi
     git clone https://github.com/citrineos/citrineos-core
     ```
 
-1. Navigate to the `citrineos-core/Server` directory and run the init-all script:
+1. Navigate to the `citrineos-core/Server` directory and run the entire required stack with docker-compose.
 
     ```shell
     cd citrineos-core/Server
-    ./unix-init-install-all.sh
-    ```
-
-    This script goes through all the modules required for the sever to run, builds them and then installs them into the server's node_modules directory.
-
-1. Now you can run the entire required stack with docker-compose.
-
-    ```shell
     docker-compose up -d 
     ```
 


### PR DESCRIPTION
The old installation method was removed by this commit: https://github.com/citrineos/citrineos-core/commit/831bee31603ea6bf0e752625928aa657d8d6c344#diff-fdf4dbb9c11af6577140d[…]956ebf4e3216a94941d1f8fd87a