### PR TITLE
Added OCPI detail to quick start

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,9 +10,9 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.16.3)
-    ffi (1.16.3-x64-mingw-ucrt)
+    ffi (1.16.3-x64-unknown)
     forwardable-extended (2.6.0)
-    google-protobuf (3.24.4-x64-mingw-ucrt)
+    google-protobuf (3.24.4-x64-unknown)
     google-protobuf (3.24.4-x86_64-darwin)
     google-protobuf (3.24.4-x86_64-linux)
     http_parser.rb (0.8.0)
@@ -54,25 +54,24 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (5.0.3)
+    rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.6)
     rouge (4.1.3)
     safe_yaml (1.0.5)
-    sass-embedded (1.69.3-x64-mingw-ucrt)
+    sass-embedded (1.63.6)
       google-protobuf (~> 3.23)
-    sass-embedded (1.69.3-x86_64-darwin)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.69.3-x86_64-linux-gnu)
-      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.5.0)
     webrick (1.8.1)
 
 PLATFORMS
-  x64-mingw-ucrt
+  ruby
+  x64-unknown
   x86_64-darwin-21
   x86_64-darwin-23
   x86_64-linux
@@ -83,4 +82,4 @@ DEPENDENCIES
   jekyll-sitemap
 
 BUNDLED WITH
-   2.4.20
+   2.4.22

--- a/quickstart.md
+++ b/quickstart.md
@@ -10,30 +10,25 @@ on [Pre-Setup](/pre-setup.html)
 
 ## Installation
 
-1. Clone the CitrineOS repository to your local machine:
+**1. Clone the `citrineos/core` repository onto your local machine:**
 
-    ```shell
     git clone https://github.com/citrineos/citrineos-core
-    ```
 
-1. Navigate to the `citrineos-core/Server` directory and run the entire required stack with docker-compose.
+To include OCPI, additionally clone the `citrineos/ocpi` repository:
 
-    ```shell
+    git clone https://github.com/citrineos/citrineos-ocpi
+
+**2. Navigate to the `citrineos-core/Server` directory:**
+
     cd citrineos-core/Server
-    docker-compose up -d 
-    ```
 
-    The expected outcome should look like this:
-    
-    ```txt
-    [+] Running 5/6
-   - Network server_default          Created                                 28.0s
-   ✔ Container server-amqp-broker-1  Healthy                                19.3s
-   ✔ Container server-ocpp-db-1      Healthy                                11.4s
-   ✔ Container server-redis-1        Healthy                                16.3s
-   ✔ Container server-directus-1     Healthy                                27.1s
-   ✔ Container server-citrine-1      Started                                27.7s
-      ```
+**3. Start the entire `citrineos-core` stack with docker-compose:**
+
+    docker compose up -d
+
+Alternatively, to start with OCPI:
+
+    docker compose -f docker-compose.with.ocpi.yml build    
 
 ### After Setup
 
@@ -51,6 +46,8 @@ You now have a running CitrineOS server plus the supporting infrastructure, in t
 - [Redis](https://redis.io/) cache; the default settings will use an in-memory cache but the redis instance is available to use.
 
 - OCPP Citrine Server running the CSMS. You can retrieve the generated OpenAPI docs at [localhost:8080/docs](http://localhost:8080/docs). There is an unsecured websocket server (security profile '0') at `ws://localhost:8081`, and a security profile 1 websocket server at `ws://localhost:8082`.
+
+- If Citrine Server was started with OCPI enabled, you can retrieve the generated OpenAPI docs at [localhost:8085/docs](http://localhost:8085/docs).
 
 > Please consider that this setup is the development environment and **do not** simply deploy it to an exposed
 > environment with initial passwords!


### PR DESCRIPTION
Added instructions on how to start citrine with OCPI.

Some minor clean up included as well.

I do think that  this quick start page can be refined more in the future. Ideally, the quick start page is a single page that is concise as possible. As it stands, our quick start page is two pages long and includes detailed information on usage and testing. My worry is that the abundance of information may be a turn off for prospective users.

**Before:**
<img width="1266" alt="Screenshot 2024-07-05 at 14 14 21" src="https://github.com/citrineos/citrineos.github.io/assets/14906622/a497db25-d473-494f-8356-ed02de88c8e4">

**After:**
<img width="1272" alt="Screenshot 2024-07-05 at 14 13 58" src="https://github.com/citrineos/citrineos.github.io/assets/14906622/24c59526-5dc0-4f78-8b36-b626f41894e9">
