### PR TITLE
Formatting fixes for lists

### DIFF
--- a/docs/core-concepts/architecture.md
+++ b/docs/core-concepts/architecture.md
@@ -24,6 +24,7 @@ All OCPP messages and datatypes are here as well.
 
 #### Decorators
 We make use of custom decorators that define methodes to be used for specific logic use cases.
+
 - `@AsHandler`:Defines a method as an OCPP call handler that listens for specific OCPP messages types from the message broker.
 - `@AsMessageEndpoint`: Defines a method as a Fastify-exposed API endpoint that takes in HTTP requests that are sent to a charging station.
 - `@AsDataEndpoint`: Defines a method as a Fastify-exposed API endpoint that exposes CRUD functionality for entities defined in the 01_Data package.
@@ -43,6 +44,7 @@ New modules which add persistent datatypes will need to extend this package.
 02_Util contains implementations of various infrastructure components and tools.
 
 This includes:
+
 - Cache implementations, such as [redis](https://github.com/redis/redis) and a simple Javascript in-memory cache
 - Message broker implementations such as [google pubsub](https://github.com/googleapis/nodejs-pubsub), [kafka](https://github.com/tulios/kafkajs), and an AMPQP-compatible implementation using [amqlib](https://github.com/amqp-node/amqplib). 
 - Network connection implementation such as websockets
@@ -58,6 +60,7 @@ Citrine is set up that Modules have the actual implementations of OCPP Functiona
 They pull in the other packages like 00_base, 01_Data, 02_Util and are built on top.
 
 The structure for each module should be roughly the same, set up as:
+
 - `api.ts`: Defines the API endpoints for the module
 - `module.ts`: Hold the `@AsHandler` decorated methods that handle OCPP messages. Here you will also find the supported call actions listed in an array at the top.
 - `service.ts`: Offers the deeper logic for the OCPP functional Blocks and is called by the methods in `module.ts`
@@ -99,7 +102,7 @@ Is responsible for handling Transaction related functionality. Example message a
 
 ### Server
 
-The server directory is an example implementation using the citrine modules.
+The server directory is an example implementation using the Citrine modules.
 It is not designed for production use, but rather for local development and test environments.
 Citrine is designed in a modular fashion scale each module independently.
 If you want to just use it for local development, check out our guide here: [Getting Started](../getting-started/getting-started.md)

--- a/docs/getting-started/running-ocpi.md
+++ b/docs/getting-started/running-ocpi.md
@@ -25,7 +25,7 @@ The setup process for running CORE with OCPI is very similar to running CORE alo
 Alternatively, you should also be able to run `npm run start-docker-compose`, which will use the 
 `./Server/docker-compose.yml` configuration to `docker compose up`.
 
-Now along with all of the CORE components, you will also have Citrine OCPI Server [localhost:8085](http://localhost:8085) with Swagger UI docs available at [localhost:8085/docs](http://localhost:8085/docs).|
+Now along with all of the CORE components, you will also have Citrine OCPI Server [localhost:8085](http://localhost:8085) with Swagger UI docs available at [localhost:8085/docs](http://localhost:8085/docs).
 
 ### Configuration
 

--- a/docs/getting-started/testing-with-everest.md
+++ b/docs/getting-started/testing-with-everest.md
@@ -50,8 +50,8 @@ Docker container. Conveniently, the logs are in HTML format, so we can easily vi
 
 # Running EVerest Manually
 You can also use their demo repository that hosts a Docker packaged EVerest image. [See here for Github Repo](https://github.com/EVerest/everest-demo)
-
 To get EVerest running on the side while developing and making changes, you can follow the steps below.
+
 1. Run your CitrineOS instance locally with `docker compose up -d` in the CitrineOS repository.
 1. Clone the [EVerest Demo](https://github.com/EVerest/everest-demo) repository and `cd` into the repo.
 1. With CitrineOS running execute an "add charger" script at `./citrineos/add-charger.sh` This adds a charger, location and password for the charger to CitrineOS.

--- a/docs/references.md
+++ b/docs/references.md
@@ -6,5 +6,6 @@ title: References
 
 Want to read more about what we based our project on?
 Take a look at the following urls:
+
 - [OCPP 2.0.1](https://openchargealliance.org/protocols/open-charge-point-protocol/#OCPP2.0.1)
 - [OCTT (OCPP Testing tool)](https://openchargealliance.org/test-tool/)


### PR DESCRIPTION
Formatting fixes for lists to display correctly with mkdocs.
Lists need to have an empty line before them, else they are all seen as a single line. 