### PR TITLE
Updated Node.js version for Prerequisites

### DIFF
--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -11,7 +11,7 @@ Our project is written in [Typescript](https://www.typescriptlang.org) and is ba
 For development purposes you can either run our project fully native on your machine or run it in docker using our `docker-compose` file.
 For either path please ensure the following things are installed on your local system:
 
-- Node.js: [Download Node.js](https://nodejs.org/en/download/) greater than version 18
+- Node.js: [Download Node.js](https://nodejs.org/en/download/) greater than version 22.11
 - npm (Node Package Manager): [Download npm](https://www.npmjs.com/get-npm)
 - Docker: [Download Docker](https://www.docker.com/)
 - Docker Compose: [Install Docker Compose plugin](https://docs.docker.com/compose/install/)


### PR DESCRIPTION
Hi,

Updated the README to specify Node.js v22.11 or higher as a prerequisite, in alignment with the package.json.

Please review.

Thanks!