### PR TITLE
2.0 Docs+ (FAQs page)

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -6,7 +6,7 @@ title: FAQs (Frequently Asked Questions)
     type: info
     open: true
 
-OCPP 1.6, 2.0.1, and 2.1 are supported by CitrineOS. For more information about the differences between versions, 
+OCPP 1.6 and 2.x are supported by CitrineOS. For more information about the differences between versions, 
 [click here](https://openchargealliance.org/protocols/open-charge-point-protocol/).
 ///
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -31,5 +31,5 @@ information about the Core REST API, [click here](/apis/core-api).
     type: info
     open: true
 
-OCPI 2.2.1 is supported by CitrineOS. Refer to the [roadmap](/roadmap) for information on upcoming OCPI versions.
+OCPI 2.2.1 is supported by CitrineOS. Refer to the [roadmap](/roadmap) for information on upcoming OCPI version support.
 ///

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -18,11 +18,11 @@ Yes, CitrineOS can support chargers using different protocols at the same time. 
 based on the protocol sent as part of the websocket connection.
 ///
 
-/// details | APIs?
+/// details | What APIs are available?
     type: info
     open: true
     
-CitrineOS uses REST API to support communications with the Charging Station and GraphQL to support database operations. For more
+CitrineOS uses REST API to support communications with charging stations and GraphQL to support database operations. For more
 information about the Core REST API, [click here](/apis/core-api).
 
 ///
@@ -32,4 +32,12 @@ information about the Core REST API, [click here](/apis/core-api).
     open: true
 
 OCPI 2.2.1 is supported by CitrineOS. Refer to the [roadmap](/roadmap) for information on upcoming OCPI version support.
+///
+
+/// details | What technologies support CitrineOS?
+    type: info
+    open: true
+
+CitrineOS is a TypeScript-based Node.js application with a PostgreSQL database and RabbitMQ message broker. The Operator UI
+is a NextJS-based web application with GraphQL integration to CitrineOS's data.
 ///

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -2,7 +2,7 @@
 title: FAQs (Frequently Asked Questions)
 ---
 
-/// details | What OCPP Protocols are supported?
+/// details | What versions OCPP are supported?
     type: info
     open: true
 
@@ -18,10 +18,18 @@ Yes, CitrineOS can support chargers using different protocols at the same time. 
 based on the protocol sent as part of the websocket connection.
 ///
 
-/// details | What APIs does CitrineOS use?
+/// details | APIs?
     type: info
     open: true
     
-CitrineOS uses REST API to support communications with the Charging Station and GraphQL to support database operations.
+CitrineOS uses REST API to support communications with the Charging Station and GraphQL to support database operations. For more
+information about the Core REST API, [click here](/apis/core-api).
 
+///
+
+/// details | What versions of OCPI are supported?
+    type: info
+    open: true
+
+OCPI 2.2.1 is supported by CitrineOS. Refer to the [roadmap](/roadmap) for information on upcoming OCPI versions.
 ///

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -1,0 +1,27 @@
+---
+title: FAQs (Frequently Asked Questions)
+---
+
+/// details | What OCPP Protocols are supported?
+    type: info
+    open: true
+
+OCPP 1.6, 2.0.1, and 2.1 are supported by CitrineOS. For more information about the differences between versions, 
+[click here](https://openchargealliance.org/protocols/open-charge-point-protocol/).
+///
+
+/// details | Can CitrineOS support multiple protocols at the same time?
+    type: info
+    open: true
+
+Yes, CitrineOS can support chargers using different protocols at the same time. CitrineOS knows the protocol of the charger
+based on the protocol sent as part of the websocket connection.
+///
+
+/// details | What APIs does CitrineOS use?
+    type: info
+    open: true
+    
+CitrineOS uses REST API to support communications with the Charging Station and GraphQL to support database operations.
+
+///

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ nav:
   - index.md
   - roadmap.md
   - references.md
+  - faqs.md
   - Getting Started:
       - getting-started/prerequisites.md
       - getting-started/getting-started.md
@@ -98,6 +99,7 @@ markdown_extensions:
       permalink: "#"
       baselevel: 2
   - pymdownx.blocks.caption
+  - pymdownx.blocks.details
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid


### PR DESCRIPTION
Keeping this PR separate from [the main 2.0 docs PR ](https://github.com/citrineos/citrineos.github.io/pull/54) to focus in on what potential FAQs we can add. For now, they look like this (all collapsibles default open):

<img width="1182" height="677" alt="image" src="https://github.com/user-attachments/assets/83d9a369-ded5-4459-8027-12076e502575" />

You can also collapse all the items as you like:
<img width="1182" height="677" alt="image" src="https://github.com/user-attachments/assets/9b4d5bac-aaec-4713-b393-6b8743527f7a" />
