### PR TITLE
docs: fix broken clone path and clarify wscat verification in Getting Started

### DIFF
--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -13,9 +13,9 @@ In this section, we assume you have set up the necessary [prerequisites](prerequ
 
     git clone https://github.com/citrineos/citrineos-core
 
-**2. Navigate to the `citrineos-core/Server` directory:**
+**2. Navigate into the repository:**
 
-    cd citrineos-core/Server
+    cd citrineos-core
 
 **3. Start the entire `citrineos-core` stack with docker-compose:**
 
@@ -33,9 +33,24 @@ You should now have the following services running:
 | **RabbitMQ**                                  | [amqp://guest:guest@localhost:5672](amqp://guest:guest@localhost:5672)                       | [RabbitMQ](http://rabbitmq.com) message bus.                                                                                                                                                                         |
 | **Redis**                                     | N/A                                                                                          | The default settings will use an in-memory cache but a [Redis](https://redis.io/) instance is available to use.                                                                                                      |
 
-Quickly verify the connection to the server by using `wscat` to send an `BootNotification`:
+Quickly verify the connection to the server by using `wscat` to connect and send a `BootNotification`.
+
+First, connect to the server:
+```bash
+wscat -c ws://localhost:8081/{STATION_ID} -s ocpp2.0.1
 ```
-wscat -c ws://localhost:8081/{STATION_ID} -x '[
+
+Then, paste the following `BootNotification` message into the prompt and press Enter.
+
+> **Note:** `wscat` reads input line-by-line, so the JSON message **must** be pasted as a single line:
+
+```json
+[2, "15106be4-57ca-11ee-8c99-0242ac120003", "BootNotification", {"reason": "PowerUp", "chargingStation": {"model": "SingleSocketCharger", "vendorName": "VendorX"}}]
+```
+
+*(Formatted view for readability):*
+```json
+[
   2,
   "15106be4-57ca-11ee-8c99-0242ac120003",
   "BootNotification",
@@ -46,7 +61,20 @@ wscat -c ws://localhost:8081/{STATION_ID} -x '[
       "vendorName": "VendorX"
     }
   }
-]'
+]
+```
+
+You should receive a response indicating the boot was accepted, which confirms the app is working:
+```json
+[
+  3,
+  "15106be4-57ca-11ee-8c99-0242ac120003",
+  {
+    "currentTime": "2023-10-18T12:00:00.000Z",
+    "interval": 60,
+    "status": "Accepted"
+  }
+]
 ```
 
 ### Running Operator UI (Beta)


### PR DESCRIPTION
Closes citrineos/citrineos#220

## Problem

Two things in the Getting Started guide stop a new user cold.

**1. Step 2 points at a directory that doesn't exist.** The guide says:

    cd citrineos-core/Server

There is no `Server/` directory in `citrineos-core@main`. So this
step fails with "No such file or directory" and the guide dead-ends before the first
`docker compose` call.

**2. The wscat verification snippet can't be run as written.** It omits the WebSocket
subprotocol, and it passes a pretty-printed multi-line JSON payload to `wscat -x`, which
reads input line by line. Copy-pasting it does not produce a BootNotification.

## Changes

- **Step 2** now navigates to the repository root (`cd citrineos-core`), which is where
  `docker-compose.yml` lives.
- **Verification section** reworked into two steps: connect with
  `wscat -c ws://localhost:8081/{STATION_ID} -s ocpp2.0.1`, then paste the payload.
  The payload is given as a single line (with a formatted copy alongside for readability)
  and a note explains why. Added the expected `BootNotificationResponse` so users can
  confirm the stack is up rather than guessing.

## Verification

- `mkdocs build --strict` passes with no new warnings.
- Ran the revised steps end to end against a fresh clone of `citrineos-core@main`.

## Notes for reviewers

This PR is deliberately scoped to the two blocking problems. 
